### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+w3c-sgml-lib (1.3-2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since stretch:
+    + Build-Depends: Drop versioned constraint on debhelper and xml-core.
+    + w3c-sgml-lib: Drop versioned constraint on w3c-markup-validator in Breaks.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 15 Jun 2021 22:17:02 -0000
+
 w3c-sgml-lib (1.3-1) unstable; urgency=low
 
   * New upstream release (Closes: #665298)

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: w3c-sgml-lib
 Section: text
 Priority: optional
 Maintainer: Nicholas Bamber <nicholas@periapt.co.uk>
-Build-Depends: debhelper (>= 9.20120909), xml-core (>= 0.13+nmu2~),
+Build-Depends: debhelper, xml-core,
  libreadonly-perl, libxml-libxml-perl, libautodie-perl
 Standards-Version: 3.9.4
 Homepage: http://validator.w3.org/sgml-lib
@@ -12,7 +12,6 @@ Vcs-Browser: https://github.com/periapt/w3c-sgml-lib
 Package: w3c-sgml-lib
 Architecture: all
 Depends: ${misc:Depends}
-Breaks: w3c-markup-validator (<< 1.2+dfsg-6)
 Conflicts: w3c-dtd-xhtml
 Description: w3.org DTD and catalog files
  This package consists of all the definition files used by the 


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/w3c-sgml-lib/0ab67681-51e0-4031-8795-3ac64313f126.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* [-Breaks: w3c-markup-validator (<< 1.2+dfsg-6)-]


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/0ab67681-51e0-4031-8795-3ac64313f126/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/0ab67681-51e0-4031-8795-3ac64313f126/diffoscope)).
